### PR TITLE
docs: fix the docker package install line to run headless

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -227,7 +227,7 @@ before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
-  - sudo apt-get -y install docker-ce
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install docker-ce -y
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Without this bit, the install hangs waiting for user input.